### PR TITLE
gh09 - Failure to integrate h2leveldb with Mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 Copyright (c) 2014-2016 by Tatsuya Kawano
 
 **Authors:** Tatsuya Kawano ([`tatsuya@hibaridb.org`](mailto:tatsuya@hibaridb.org)).
+
 Also see the [Credits](#credits) chapter. h2leveldb borrowed port
 driver C/C++ codes from LETS.
 
 **h2leveldb** is Erlang bindings to HyperLevelDB embedded key-value
-store that can be used in any Erlang application. It is open sourced
-under the MIT license. It was originally developed for
+store that can be used in any Erlang or Elixir application. It is open
+sourced under the MIT license. It was originally developed for
 [Hibari DB](https://github.com/hibari/hibari) and that is why it was
 named as an abbreviation of Hibari HyperLevelDB. Despite the name
 suggests, it does not depend on any components of Hibari DB.
@@ -27,7 +28,7 @@ recommend to take a look at other projects such as
 of ETS (Erlang Term Storage) using LevelDB or HyperLevelDB as the
 storage implementation.
 
-### Notes About Implementation
+### Notes About The Implementation
 
 h2leveldb is implemented as an Erlang port driver (not NIFs). It
 takes advantage of the async thread pool in an Erlang VM to perform
@@ -76,8 +77,13 @@ For more information, please see the
 [README file](https://code.google.com/p/snappy/source/browse/trunk/README)
 of Snappy.
 
-
 ## Usage Examples
+
+Here are some basic usage examples written in Erlang. If you are using
+Elixir, do not forget to replace char list `"/tmp/ldb.leveldb1"` in
+Erlang with `'/tmp/ldb.leveldb1'` in Elixir, and binary `<<"key1">>`
+with `"key1"`.
+
 
 ### Basic CRUD Operations
 
@@ -156,72 +162,145 @@ of Snappy.
 See the [eunit test cases](https://github.com/leveldb-erlang/h2leveldb/blob/master/test/eunit/h2leveldb_test.erl).
 
 
-## Adding h2leveldb to Your Project
+## System Requirements
 
-### Requirements
+### Erlang/OTP 18 and 17
 
-#### Erlang/OTP 18, 17 and R16B
+Recently tested with the following Erlang/OTP releases:
 
-Recently tested with:
+- Erlang/OTP 18.3.3 (64 bit)
+- Erlang/OTP 17.5.6.8 (64 bit)
 
-- Erlang/OTP 18.0 (64 bit)
-- Erlang/OTP 17.5 (64 bit)
-- Erlang/OTP R16B03-1 (64 bit)
+If you want to build it on an older releases such as R16B03-1 (64
+bit), please let me know by creating
+[a GitHub issue](https://github.com/leveldb-erlang/h2leveldb/issues).
 
-#### Unix like OS such as GNU/Linux, BSD and illumos(*1)
+### Unix like OS such as Linux, BSD and illumos[1]
 
-h2leveldb will run on virtually any Unix like operating systems such
-as GNU/Linux, BSD and illumos. Although I have not tested, it will run
-on Mac OS X too with a little change in h2leveldb/c_src/build_deps.sh
-script.
+h2leveldb will run on any Unix like operating systems such as Linux,
+BSD and illumos. Although I have not tested, it will run on OS X too
+with a little change in h2leveldb/c_src/build_deps.sh script.
 
-- **1:** illumos derives from OpenSolaris. OmniOS and SmartOS will be
-  good options for illumos based servers.
+- **1**: [illumos](http://wiki.illumos.org/display/illumos/About+illumos)
+  is the open source fork of Sun's OpenSolaris. OmniOS and SmartOS
+  will be good options for illumos based servers.
 
 **Recently tested with:**
 
-I am developing and regularly testing h2leveldb on the following
-platforms.
+I am developing h2leveldb and regularly testing it on the following
+platforms:
 
-| OS        |            | Release          | Arch   | Compiler    | Erlang/OTP           | File System |
-|:----------|:-----------|:-----------------|:-------|:------------|----------------------|:------------|
-| GNU/Linux | Arch Linux | 2015.07.01       | x86_64 | GCC 5.2.0   | 18.0, 17.5, R16B03-1 | XFS         |
-| BSD       | FreeBSD    | 10.1-RELEASE-p16 | amd64  | Clang 3.4.1 | 18.0, 17.5, R16B03-1 | ZFS         |
-| illumos   | SmartOS    | pkgin 2014Q1     | amd64  | GCC 4.7.3   | R16B02               | ZFS         |
+| OS    |          | Release         | Arch   | Compiler    | Erlang/OTP       | File System |
+|:------|:---------|:----------------|:-------|:------------|------------------|:------------|
+| Linux | CentOS 7 | 7.2.1511        | x86_64 | GCC 4.8.5   | 18.3.3, 17.5.6.8 | XFS         |
+| Linux | CentOS 6 | 6.8             | x86_64 | GCC 4.4.7   | 18.3.3, 17.5.6.8 | EXT4        |
+| BSD   | FreeBSD  | 10.3-RELEASE-p5 | amd64  | Clang 3.4.1 | 18.3.3, 17.5.6.8 | ZFS         |
 
 **Other platforms:**
 
-In addition to above, I tried the following platforms to see if
-I can build and run h2leveldb.
+I once tried an older version of h2leveldb on the following platforms:
 
-| OS        |            | Release      | Arch   | Compiler  | Erlang/OTP     | File System |
-|:----------|:-----------|:-------------|:-------|:----------|:---------------|:------------|
-| GNU/Linux | CentOS 7   | 7.1.1503     | x86_64 | GCC 4.8.3 | 18.0, 17.5     | XFS         |
-| GNU/Linux | CentOS 6   | 6.6          | x86_64 | GCC 4.4.7 | 18.0, 17.5     | EXT4        |
-| illumos   | OmniOS     | r151008j-r1  | amd64  | GCC 4.8.1 | 17.0           | ZFS         |
+| OS      |         | Release      | Arch  | Compiler  | Erlang/OTP | File System |
+|:--------|:--------|:-------------|:------|:----------|:-----------|:------------|
+| illumos | SmartOS | pkgin 2014Q1 | amd64 | GCC 4.7.3 | R16B02     | ZFS         |
+| illumos | OmniOS  | r151008j-r1  | amd64 | GCC 4.8.1 | 17.0       | ZFS         |
 
-- (**TODO**) Try Ubuntu "Trusty" 14.04 LTS x86_64.
 
-### Install Build Dependencies
+## Adding h2leveldb to Your Erlang or Elixir Project
+
+### Erlang Based Project
+
+1. Add h2leveldb to your rebar.config:
+
+   ```erlang
+   {deps, [{h2leveldb, "", {git, "git://github.com/leveldb-erlang/h2leveldb",
+                            {branch, "master"}}}
+
+           %% other deps ...
+           ]}.
+   ```
+
+1. Install [build dependencies](#installing-build-dependencies).
+
+1. Build and run your project:
+
+   ```sh
+   $ rebar get-deps
+   $ rebar compile
+   $ rebar shell
+   ```
+
+
+### Elixir Based Project
+
+1. Add h2leveldb and override its dependencies to your mix.exs:
+
+   ```elixir
+   defp deps do
+    [{:h2leveldb, git: "https://github.com/leveldb-erlang/h2leveldb.git",
+      tag: "master"},
+     {:HyperLevelDB, git: "https://github.com/leveldb-erlang/HyperLevelDB.git",
+      compile: false, app: false, override: true},
+     {:snappy, git: "https://github.com/leveldb-erlang/snappy.git",
+      compile: false, app: false, override: true},
+
+     # other deps ...
+    ]
+  end
+  ```
+
+1. Install [build dependencies](#installing-build-dependencies).
+
+1. Build and run your project:
+
+   ```sh
+   $ mix deps.get
+   $ mix compile
+   $ iex -S mix
+   ```
+
+## Installing Build Dependencies
 
 h2leveldb requires **GNU Autotools** and their dependencies. It also
 requires **git** to download HyperLevelDB and Snappy source codes. Of
-course, you need **Erlang/OTP R16B or newer**.
+course, you need **Erlang/OTP 17 or newer**.
 
-#### GNU/Linux - Fedora, RHEL 7, CentOS 7
+- [Arch Linux](#linux---arch-linux)
+- [Debian and Ubuntu](#linux---debian-and-ubuntu)
+- [Fedora, RHEL 7 and CentOS 7](#linux---fedora-rhel-7-and-centos-7)
+- [RHEL 6 and CentOS 6](#linux---rhel-6-and-centos-6)
+- [FreeBSD](#freebsd)
+- [SmartOS](#illumos---smartos)
+- [OmniOS](#illumos---omnios)
+
+
+### Linux - Arch Linux
+
+```sh
+$ sudo pacman -S gcc make autoconf automake libtool git
+```
+
+### Linux - Debian and Ubuntu
+
+```sh
+$ sudo apt-get install gcc g++ make autoconf automake libtool git
+```
+
+### Linux - Fedora, RHEL 7 and CentOS 7
 
 ```sh
 $ sudo yum install gcc gcc-c++ make autoconf automake libtool git
 ```
 
-#### GNU/Linux - RHEL 6 and CentOS 6
+### Linux - RHEL 6 and CentOS 6
 
 ```sh
 $ sudo yum install gcc gcc-c++ make libtool git wget
 ```
 
 autoconf and automake in RHEL 6/Cent OS 6 yum repositories will be too
-old to build Snappy. Build and install the latest version from source.
+old to build Snappy. Build and install recent versions from their
+source codes.
 
 **autoconf**
 
@@ -251,19 +330,7 @@ $ cd ..
 $ rm -rf automake-1.15*
 ```
 
-#### GNU/Linux - Debian, Ubuntu
-
-```sh
-$ sudo apt-get install gcc g++ make autoconf automake libtool git
-```
-
-#### GNU/Linux - Arch Linux
-
-```sh
-$ sudo pacman -S gcc make autoconf automake libtool git
-```
-
-#### FreeBSD
+### FreeBSD
 
 For FreeBSD 10.0-RELEASE or newer, you can use pkgng to install
 pre-built packages.
@@ -272,13 +339,14 @@ pre-built packages.
 $ sudo pkg install bash gmake autoconf automake libtool git
 ```
 
-I have not tested h2leveldb with older FreeBSD releases, and I think
+I have not tested h2leveldb on older FreeBSD releases, and I think
 build will fail because h2leveldb's reber.config assumes that you are
 using Clang as C/C++ compiler and its standard C++ library is
 available. This may not be true on an older FreeBSD release. You could
 solve this by replacing `-lc++` in reber.config with `-lstdc++`.
 
-#### illumos - SmartOS
+
+### illumos - SmartOS
 
 Running h2leveldb in the global zone is not supported. Create a
 SmartOS zone by `vmadm` and run the following commands inside the
@@ -297,7 +365,8 @@ $ sudo pkgin in erlang
 - **TODO**: Build and install Erlang
   * e.g http://christophermeiklejohn.com/ruby/smartos/2013/10/15/erlang-on-smartos.html
 
-#### illumos - OmniOS
+
+### illumos - OmniOS
 
 Erlang/OTP in the official package repository is too old and cannot be
 used for h2leveldb. You need to build and install R16B03-1 or 17.x
@@ -354,15 +423,6 @@ $ sudo pkg install \
    developer/versioning/git
 ```
 
-### Build Your Project with h2leveldb
-
-To build your project with h2leveldb, run the following commands:
-
-```sh
-$ ./rebar get-deps
-$ ./rebar compile
-```
-
 
 ## Performance Tips
 
@@ -405,13 +465,12 @@ borrowed port driver C/C++ codes form LETS.
 
 ## TODO
 
-- Add QuickCheck test cases.
-- Add `get_many/5` operation to move the load for partial or full DB
+- [ ] Add `get_many/5` operation to move the load for partial or full DB
   scan from Erlang land to C++ land. I found repeating `next/3` and
   `get/3` calls hogs the CPU so I believe this will be better handled
   in C++ land.
-- More informative error messages. Right now, it will only return
+- [ ] More informative error messages. Right now, it will only return
   `{error, io_error}` for any kind of errors occurred in HyperLevelDB.
-- Add bloom filter policy (See: Performance -> Filter section of the
+- [ ] Add bloom filter policy (See: Performance -> Filter section of the
   [LevelDB document](http://leveldb.googlecode.com/svn/trunk/doc/index.html).)
-- Perhaps add DTrace provider?
+- [ ] Add QuickCheck test cases.

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -116,6 +116,16 @@ case "$1" in
         ;;
 
     *)
+        # a workaround for a problem in Elixir Mix
+        if [ ! -d $REBAR_DEPS_DIR/snappy/.git ]; then
+            ORIGINAL_REBAR_DEPS_DIR="$REBAR_DEPS_DIR"
+            REBAR_DEPS_DIR="$BASEDIR/../.."
+            echo
+            echo "NOTE: Invalid \$REBAR_DEPS_DIR: '${ORIGINAL_REBAR_DEPS_DIR}'"
+            echo "Falling-back to: '${REBAR_DEPS_DIR}'"
+            echo
+        fi
+
         # snappy
         if [ ! -f $BASEDIR/snappy/lib/libsnappy.a ]; then
             LIBTOOLIZE=libtoolize

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -118,12 +118,7 @@ case "$1" in
     *)
         # a workaround for a problem in Elixir Mix
         if [ ! -d $REBAR_DEPS_DIR/snappy/.git ]; then
-            ORIGINAL_REBAR_DEPS_DIR="$REBAR_DEPS_DIR"
             REBAR_DEPS_DIR="$BASEDIR/../.."
-            echo
-            echo "NOTE: Invalid \$REBAR_DEPS_DIR: '${ORIGINAL_REBAR_DEPS_DIR}'"
-            echo "Falling-back to: '${REBAR_DEPS_DIR}'"
-            echo
         fi
 
         # snappy


### PR DESCRIPTION
- Add a workaroud for a problem that `$REBAR_DEPS_DIR` is set to a wrong directory when Rebar is executed by Elixir Mix. (See details: https://github.com/leveldb-erlang/h2leveldb/issues/9#issuecomment-223259952)
- Update README; add sample rebar.conf and mix.exs, etc.
